### PR TITLE
Feat/15 카페상세+메뉴리스트 페이지가 추가되었습니다!

### DIFF
--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import Card from 'react-bootstrap/Card';
+import Modal from 'react-bootstrap/Modal';
+import Button from "react-bootstrap/esm/Button";
+
+const Menu = ({menuObj}) => {
+  const userInfo = JSON.parse(window.localStorage.getItem('userInfo')); // 로그인한 유저 객체
+  const userPoint = userInfo.point; // 유저포인트
+
+  console.log(menuObj);
+  console.log(menuObj.name);
+
+  const [showOrderModal, setShowOrderModal] = useState(false);
+
+  const handleShowOrderModal = () => {
+    setShowOrderModal(true);
+  };
+
+  const handleCloseOrderModal = () => {
+    setShowOrderModal(false);
+  };
+
+  return (
+    <div>
+      {/* 메뉴 표시: Card 사용 */}
+      <Card style={{ display: "flex", alignItems: "stretch", width: "100%", height: "100%", borderRadius: "10px", border: "none" }}>
+        {/* 이미지 표시 */}
+        <div style={{ aspectRatio: "1/1", backgroundColor: "lightgrey" }}></div>
+        <Card.Body>
+          <Card.Title style={{fontSize:"18px"}}>{menuObj.name}</Card.Title>
+          <Card.Text style={{fontSize:"16px", color:"mediumpurple"}}>{menuObj.price}</Card.Text>
+        </Card.Body>
+      </Card>
+      <button style={{ width: "100%", height: "100%", color: "grey", borderColor: "lightgrey", borderWidth: "1px"}} onClick={handleShowOrderModal}>
+        주문하기
+      </button>
+
+      {showOrderModal && ( // showOrderModal 상태에 따라 모달 창 렌더링
+        <Modal show={showOrderModal} onHide={handleCloseOrderModal} size="lg">
+          <Modal.Header><h4>주문하시겠습니까?</h4></Modal.Header>
+          <Modal.Body style={{ display: "flex" }}>
+              메뉴: {menuObj.name} <br />
+              가격: {menuObj.price} <br />
+              <br />
+              보유포인트: {userPoint}
+          </Modal.Body>
+          <Modal.Footer>
+            <div>
+              <Button variant="primary" type="submit" onClick={() => alert('주문완료!')} style={{ marginRight: '10px' }}>
+                주문하기
+              </Button>
+              <Button variant="secondary" type="button" onClick={handleCloseOrderModal}>
+                닫기
+              </Button>
+            </div>
+          </Modal.Footer>
+        </Modal>
+      )}
+    </div>
+  );
+};
+
+export default Menu;

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -42,7 +42,7 @@ const Menu = ({menuObj}) => {
               메뉴: {menuObj.name} <br />
               가격: {menuObj.price} <br />
               <br />
-              보유포인트: {userPoint}
+              현재 보유 중인 포인트: {userPoint}
           </Modal.Body>
           <Modal.Footer>
             <div>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,6 +3,7 @@ export { default as Footer } from './Footer';
 export { default as SignupForm } from './SignupForm';
 export { default as MyProfile } from './MyProfile';
 export { default as SigninForm } from './SigninForm';
+export { default as Menu } from './Menu';
 export { default as MyCalendar } from './MyCalendar';
 export { default as PointForm } from './PointForm';
 export { default as RecordDetail } from './RecordDetail';

--- a/src/pages/CafeDetail.jsx
+++ b/src/pages/CafeDetail.jsx
@@ -8,7 +8,7 @@ import { Menu } from '../components';
 /* const cafeObj = { 
     'name': '카페123', 'location': '서울시 관악구 정릉동', 
     'detail': 'ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ', 
-    'phone': '010-1234-5678', 
+    XXX'phone': '010-1234-5678',XXX 
     'menu': [
         {'name': '카페라떼', 'price': '4000원'},
         {'name': '아메리카노', 'price': '3000원'},
@@ -64,7 +64,8 @@ function CafeDetail() {
                                     onClick={handleShowFullText}>{showFullText ? "닫기" : "...더보기"}</span>
                                 )}
                             </p>
-                            <p>{cafeObj.phone}</p>
+                            {/* <img src="/images/call.png" alt="알림버튼" style={{ width: "20px", height: "20px" }}/>
+                            <p>{cafeObj.phone}</p> */}
                         </div>
                     </div>
                 </Col>

--- a/src/pages/CafeDetail.jsx
+++ b/src/pages/CafeDetail.jsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { Container, Row, Col } from 'react-bootstrap';
+import { Menu } from '../components';
+
+// 카페목록 페이지에서 onClick={() => navigate('/cafedetail', { state: { cafeObj } })}하면 연결되는 페이지. 이때 cafeObj의 형태는 다음과 같음
+/* const cafeObj = { 
+    'name': '카페123', 'location': '서울시 관악구 정릉동', 
+    'detail': 'ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ', 
+    'phone': '010-1234-5678', 
+    'menu': [
+        {'name': '카페라떼', 'price': '4000원'},
+        {'name': '아메리카노', 'price': '3000원'},
+        {'name': '카푸치노', 'price': '4500원'},
+        {'name': '카라멜 마끼아또', 'price': '5000원'},
+        {'name': '바닐라 라떼', 'price': '4500원'},
+        {'name': '에스프레소', 'price': '3500원'},
+        {'name': '카페모카', 'price': '4500원'},
+        {'name': '녹차 라떼', 'price': '4000원'},
+        {'name': '자몽 에이드', 'price': '4000원'},
+        {'name': '딸기 스무디', 'price': '5000원'},
+        {'name': '망고 주스', 'price': '4500원'}
+    ] 
+};
+라고 생각하고 짰음 */
+
+function CafeDetail() {
+    const location = useLocation();
+    const { cafeObj } = location.state;
+    const navigate = useNavigate();
+
+    const [menus, setMenus] = useState([]);
+    
+    const [showFullText, setShowFullText] = useState(false);
+    
+    useEffect(() => {
+        setMenus(cafeObj.menu);
+    }, []);
+
+    const handleShowFullText = () => {
+        if (!showFullText) {setShowFullText(true)}
+        else {setShowFullText(false)}
+    }
+
+    return (
+        <Container fluid>
+            <Row>
+                <Col xs={12} md={6} >
+                    <div style={{ width: "60%", margin: "0 auto", textAlign: "center" }}>
+                        <div style={{textAlign: "center"}}>
+                            <div style={{ width:"100%", aspectRatio: "1/1", backgroundColor: "lightgrey", margin:"30px auto"}}></div> {/* 세로방향 | 가로방향 */}
+                            <h4>{cafeObj.name}</h4>
+                            <p style={{color:"grey"}}>{cafeObj.location}</p>
+                        </div>
+                        <div style={{width: "100%", color:"grey", textAlign: "left"}}>
+                            <p className="overflow-text" 
+                                style={{ whitespace: "nowrap", overflow: "hidden", textoverflow: "ellipsis" }}>
+                                    {showFullText ? cafeObj.detail : cafeObj.detail.slice(0, 35)} 
+                                    {cafeObj.detail.length > 35 && ( // 텍스트 길이가 일정 이상인 경우에만 ...과 더보기 링크를 추가
+                                    <span 
+                                    className="read-more" 
+                                    style={{ color: "mediumpurple", cursor: "pointer" }} 
+                                    onClick={handleShowFullText}>{showFullText ? "닫기" : "...더보기"}</span>
+                                )}
+                            </p>
+                            <p>{cafeObj.phone}</p>
+                        </div>
+                    </div>
+                </Col>
+
+                <Col xs={12} md={6}>
+                    <Container fluid style={{marginTop: "30px", marginBottom: "150px"}}>
+                        <Row xs={1} sm={3} md={5} lg={7} xl={9} xxl={11} className="g-3" style={{ gap: '1rem' }}>
+                            {menus.map((menu) => (
+                            <Col key={menu.id} margin="5px">
+                                <Menu menuObj={menu} />
+                            </Col>
+                            ))}
+                        </Row>
+                    </Container>
+                </Col>
+            </Row>
+        </Container>
+    )
+}
+
+export default CafeDetail;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,3 +3,4 @@ export { default as Signup } from './Signup';
 export { default as Signin } from './Signin';
 export { default as Point } from './Point';
 export { default as CafeList } from './CafeList';
+export { default as CafeDetail } from './CafeDetail';


### PR DESCRIPTION
- 카페목록 페이지에서 onClick={() => navigate('/cafedetail', { state: { cafeObj } })}하면 연결되는 페이지. 
- 이때 cafeObj의 형태는 다음 주석과 같음

/* const cafeObj = { 
    'name': '카페123', 'location': '서울시 관악구 정릉동', 
    'detail': 'ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ', 
    XXX'phone': '010-1234-5678',XXX 
    'menu': [
        {'name': '카페라떼', 'price': '4000원'},
        {'name': '아메리카노', 'price': '3000원'},
        {'name': '카푸치노', 'price': '4500원'},
        {'name': '카라멜 마끼아또', 'price': '5000원'},
        {'name': '바닐라 라떼', 'price': '4500원'},
        {'name': '에스프레소', 'price': '3500원'},
        {'name': '카페모카', 'price': '4500원'},
        {'name': '녹차 라떼', 'price': '4000원'},
        {'name': '자몽 에이드', 'price': '4000원'},
        {'name': '딸기 스무디', 'price': '5000원'},
        {'name': '망고 주스', 'price': '4500원'}
    ] 
};
라고 생각하고 짰음 */